### PR TITLE
Restructure RFC Process text

### DIFF
--- a/feature-proposals.rst
+++ b/feature-proposals.rst
@@ -143,10 +143,12 @@ All voting widgets on the RFC MUST include all relevant details for that vote, a
 described in the "Required Majority" section below.
 
 To allow for timezone differences, outside commitments by RFC authors, and other deadlines,
-the cutoff timestamp to start a vote has a grace period of 8 hours in either direction.
-That is, starting a vote 45 hours after the Intent to Vote has been posted is discouraged, but
-allowed.  Similarly, starting the vote 7 days and 3 hours after the Intent to Vote was posted
-is discouraged, but allowed.
+the cutoff timestamp for the cooldown period or to start a vote has a grace period of
+8 hours in either direction. For example, the following scenarios are allowed, but discouraged.
+
+- Starting a vote 45 hours after the Intent to Vote has been posted.
+- Starting the vote 7 days and 3 hours after the Intent to Vote was posted.
+- Starting the vote 6 days and 20 hours after a Minor change cooldown period started.
 
 Voting procedure
 ================

--- a/feature-proposals.rst
+++ b/feature-proposals.rst
@@ -46,6 +46,10 @@ for improving the RFC, as extensive or minimalist as they see fit.  However,
 unrelated discussions that spin off to discuss other, related topics SHOULD
 be moved to their own email threads to minimize noise.
 
+=================
+Types of changes
+=================
+
 The author(s) of the RFC MAY make changes to the proposal at any time during the
 discussion.  Changes broadly fall into one of three categories:
 
@@ -70,6 +74,10 @@ in response to that email.  If a series of changes are included together, the wh
 announcement belongs to the highest level of any of the involved changes.  The
 initial proposal of the RFC is considered a Major change announcement.
 
+================
+Cooldown period
+================
+
 Both Major and Minor change announcements trigger a "cooldown period" to allow for
 sufficient discussion of the related changes.  During the cooldown period, no vote
 may be called.  Editorial changes do not trigger a cooldown period.
@@ -82,6 +90,10 @@ assuming no changes are made after the initial proposal.
 
 Cooldowns overlap, so if a Major change is announced, and 3 days later a Minor
 change is announced, the vote may be called 11 days (14 - 3) later.
+
+====================
+Discussion lifetime
+====================
 
 The discussion is not required to go to a vote at any particular point.  The author(s)
 MAY continue the discussion as long as they wish.  The author(s) SHOULD

--- a/feature-proposals.rst
+++ b/feature-proposals.rst
@@ -160,16 +160,16 @@ Due to the significance of the end-of-year holidays for a majority of the world,
 the voting period MUST NOT start and MUST NOT end in the period between
 December, 17th 00:00 UTC and January, 10th 00:00 UTC.
 
-After the voting period started, including after the vote closed and the RFC is
+After the voting period has started, including after the vote closed and the RFC is
 either accepted or declined, there MUST NOT be any further major or minor
 changes to the RFC text and making editorial changes SHOULD be avoided for the
 avoidance of doubt. The voting formalities (including the voting period) MUST
-NOT be changed after the vote opened. The voting period MAY be canceled within
-the first 2 days (48 hours) in case of severe issues with the RFC. Canceling a
-vote is treated as a major change and a cooldown period of 2 weeks (336 hours)
-is required before a new vote may be started. The title of all voting widgets
-MUST be changed to invalidate any votes that have been cast (e.g. by adding the
-suffix “(Restart)”).
+NOT be changed after the vote opened.
+
+The voting period MAY be canceled within the first 2 days (48 hours) in case
+of severe issues with the RFC. Canceling a vote is treated as a Major change thus
+triggers a new cooldown period. The title of all voting widgets MUST be
+changed to invalidate any votes that have been cast (e.g. by adding the suffix “(Restart)”).
 
 If issues with an accepted RFC are noticed during implementation, an errata
 section explaining the necessary changes SHOULD be added.

--- a/feature-proposals.rst
+++ b/feature-proposals.rst
@@ -50,7 +50,7 @@ Types of changes
 ================
 
 The authors of the RFC MAY make changes to the proposal at any time during the
-discussion. Changes broadly fall into one of three categories:
+discussion. Changes are categorized into three categories based on their impact:
 
 -  **Major changes** to the RFC text include any changes that would lead to a
    change in the implementation, particularly any changes to the proposed
@@ -62,8 +62,8 @@ discussion. Changes broadly fall into one of three categories:
    other changes that are not purely editorial.
 
 -  **Editorial changes** to the RFC text include non-substantive changes, such
-   as spelling, typos, changing section labels, bug fixes to existing code
-   examples, small rewordings of descriptions, and so forth.
+   as spelling, typos, changing section labels, small rewordings of descriptions,
+   and so forth.
 
 If it is unclear what level a change belongs in, the authors SHOULD assume the
 higher one.
@@ -121,8 +121,8 @@ Prior to starting a vote, RFC authors MUST post an Intent to Vote message to
 the discussion thread. The post MUST be made at least two days (48 hours) and no more than
 1 week (168 hours) before the vote is officially opened. Any feedback posted
 after the Intent to Vote message is sent SHOULD be treated the same as if it had
-been sent earlier, and any Major or Minor changes that result MUST trigger a new
-cooldown period, canceling the Intent to Vote.
+been sent earlier, and any Major or Minor changes that result from that feedback
+MUST trigger a new cooldown period, canceling the Intent to Vote.
 
 RFC authors MAY start a vote at any time, provided that all the following conditions hold:
 
@@ -137,7 +137,7 @@ RFC authors MAY start a vote at any time, provided that all the following condit
    the thread. The authors may determine what qualifies as relevant and
    substantive, but SHOULD be liberal in interpreting that.
 
-All voting widgets on the RFC MUST include all pertinent details for that vote, as
+All voting widgets on the RFC MUST include all relevant details for that vote, as
 described in the "Required Majority" section below.
 
 Voting procedure

--- a/feature-proposals.rst
+++ b/feature-proposals.rst
@@ -36,6 +36,11 @@ relationship with the original RFC.
  Discussion Phase
 ******************
 
+In the Discussion Phase, the community may review, discuss, and offer suggestions
+for improving the RFC, as extensive or minimalist as they see fit.  However,
+unrelated discussions that spin off to discuss other, related topics SHOULD
+be moved to their own email threads to minimize noise.
+
 Before an RFC may move to the voting phase a cooldown period of 2 weeks (336
 hours) MUST have elapsed. The cooldown period starts at the time of the initial
 email of the official RFC discussion thread.

--- a/feature-proposals.rst
+++ b/feature-proposals.rst
@@ -101,7 +101,7 @@ be mindful of holiday periods or in cases of significant activity on the mailing
 to allow everyone to catch up with the discussion.
 
 In order to keep RFCs "fresh," their discussion threads must have a minimum level of
-activity.  Any message to the discussion thread from anyone other than a voting announcement
+activity.  Any message to the discussion thread from anyone other than an Intent to Vote
 is sufficient to keep the RFC active.  Once an RFC discussion goes inactive, any
 new post will "reactivate" the discussion and trigger a new cooldown period.
 
@@ -112,22 +112,26 @@ new post will "reactivate" the discussion and trigger a new cooldown period.
  Voting Phase
 **************
 
-RFC authors MAY start a vote after the cooldown period has elapsed. The
-intention of starting the vote (“voting intent”) MUST be announced at least 2
-days (48 hours) before the start of the vote in the official discussion thread.
+=====================
+Voting prerequisites
+=====================
 
-RFC authors SHOULD NOT announce the voting intent when the RFC discussion is
-still ongoing and SHOULD consider all new discussion points that are brought
-forward. RFC authors SHOULD also consider all new discussion points brought
-forward after announcing the voting intent before actually proceeding with
-starting the vote. If objective improvements are brought forward after
-announcing the voting intent they SHOULD NOT be disregarded in the interest of
-time and at the expense of quality.
+Prior to starting a vote, an RFC author MUST post an Intent to Vote message to
+the discussion thread.  The post MUST be made at least two days and no more than 1 week
+(168 hours) before the vote is officially opened.  Any feedback posted after the Intent
+to Vote message is sent SHOULD be treated the same as if it had been sent earlier,
+and any Major or Minor changes that result MUST trigger a new cooldown period,
+canceling the Intent to Vote.
 
-If major or minor changes to the RFC text are made after announcing the voting
-intent, the vote MUST NOT be started. Instead the cooldown period MUST be reset
-and a new voting intent MUST be announced when the RFC is ready for voting after
-the new cooldown period has elapsed.
+An RFC author MAY start a vote at any time, provided that:
+
+- There is no cooldown period still active.
+- The discussion thread is not inactive.
+- The author has posted an intent to open the vote at least 48 hours prior, and no more
+  than one week prior.
+- There is no ongoing relevant and substantive discussion still happening in the thread.
+  The author(s) may determine what qualifies as relevant and substantive, but SHOULD be
+  liberal in interpreting that.
 
 The actual start of the vote MUST be announced on the mailing list in a separate
 thread with a ``[VOTE]`` prefix followed by the RFC title as the Subject. The

--- a/feature-proposals.rst
+++ b/feature-proposals.rst
@@ -132,8 +132,7 @@ RFC authors MAY start a vote at any time, provided that all the following condit
 
 -  The discussion thread is not inactive.
 
--  The authors has posted an intent to open the vote at least 2 days prior, and
-   no more than 7 days prior.
+-  The current time lies within the Intent to Vote lifetime.
 
 -  There is no ongoing relevant and substantive discussion still happening in
    the thread. The authors may determine what qualifies as relevant and

--- a/feature-proposals.rst
+++ b/feature-proposals.rst
@@ -57,7 +57,7 @@ discussion. Changes broadly fall into one of three categories:
    semantics or syntax, updating the API stub. It also includes adding, changing
    or removing any voting widget.
 
--  **Minor** changes to the RFC text include adding new examples, updating
+-  **Minor changes** to the RFC text include adding new examples, updating
    existing examples, adding additional explanation or clarification, or any
    other changes that are not purely editorial.
 
@@ -96,12 +96,12 @@ Discussion lifetime
 
 The discussion is not required to go to a vote at any particular point. The
 author(s) MAY continue the discussion as long as they wish. The author(s) SHOULD
-be mindful of holiday periods or in cases of significant activity on the mailing
+be mindful of holiday periods or periods of significant activity on the mailing
 list to allow everyone to catch up with the discussion.
 
 In order to keep RFCs "fresh," their discussion threads must have a minimum
-level of activity. Any message to the discussion thread from anyone other than
-an Intent to Vote is sufficient to keep the RFC active. Once an RFC discussion
+level of activity. Any message to the discussion thread from any participant 
+(excluding “Intent to Vote” messages) is sufficient to keep the RFC active. Once an RFC discussion
 goes inactive, any new post will "reactivate" the discussion and trigger a new
 cooldown period.
 
@@ -118,19 +118,19 @@ Voting prerequisites
 ====================
 
 Prior to starting a vote, an RFC author MUST post an Intent to Vote message to
-the discussion thread. The post MUST be made at least two days and no more than
+the discussion thread. The post MUST be made at least two days (48 hours) and no more than
 1 week (168 hours) before the vote is officially opened. Any feedback posted
 after the Intent to Vote message is sent SHOULD be treated the same as if it had
 been sent earlier, and any Major or Minor changes that result MUST trigger a new
 cooldown period, canceling the Intent to Vote.
 
-An RFC author MAY start a vote at any time, provided that:
+An RFC author MAY start a vote at any time, provided that all the following conditions hold:
 
 -  There is no cooldown period still active.
 
 -  The discussion thread is not inactive.
 
--  The author has posted an intent to open the vote at least 48 hours prior, and
+-  The author has posted an intent to open the vote at least 2 days prior, and
    no more than one week prior.
 
 -  There is no ongoing relevant and substantive discussion still happening in
@@ -163,14 +163,14 @@ RFC as soon as possible and no later than the announcement of the results of the
 vote.
 
 The voting period MUST be at least two weeks (336 hours), but MAY be up to four
-weeks if necessary to avoid conflict with well-known holiday periods.
+weeks (e.g. to avoid conflicts with well-known holiday periods).
 
 Due to the significance of the end-of-year holidays for a majority of the world,
 the voting period MUST NOT start and MUST NOT end in the period between
 December, 17th 00:00 UTC and January, 10th 00:00 UTC.
 
 After the voting period has started, including after the vote closed and the RFC
-is either accepted or declined, there MUST NOT be any further major or minor
+is either accepted or declined, there MUST NOT be any further Major or Minor
 changes to the RFC text and making editorial changes SHOULD be avoided for the
 avoidance of doubt. The voting details (such as the voting period or
 interpretation of secondary votes) MUST NOT be changed after the vote opened.

--- a/feature-proposals.rst
+++ b/feature-proposals.rst
@@ -65,32 +65,22 @@ in response to that email.  If a series of changes are included together, the wh
 announcement belongs to the highest level of any of the involved changes.  The
 initial proposal of the RFC is considered a Major change announcement.
 
-Before an RFC may move to the voting phase a cooldown period of 2 weeks (336
-hours) MUST have elapsed. The cooldown period starts at the time of the initial
-email of the official RFC discussion thread.
+Both Major and Minor change announcements trigger a "cooldown period" to allow for
+sufficient discussion of the related changes.  During the cooldown period, no vote
+may be called.  Editorial changes do not trigger a cooldown period.
 
-When making non-editorial / non-typographical changes to the normative section
-of the RFC text (i.e. to the actual proposal, excluding future scope, rejected
-features and references) the cooldown period MUST be reset. The cooldown period
-MUST be reset to 2 weeks (336 hours) in case of major changes. It MUST be reset
-to 1 week (168 hours) in case of minor changes if the current remaining cooldown
-period is shorter. When in doubt, the change MUST be treated as a major change.
+- The cooldown after a Major change announcement is 2 weeks (336 hours).
+- The cooldown after a Minor announcement is 1 week (168 hours).
 
+By implication, it means the minimum discussion period for any RFC is 2 weeks,
+assuming no changes are made after the initial proposal.
 
-As an example: An RFC is announced at 2025-02-01 15:00. The initial cooldown
-period ends at 2025-02-15 15:00. On 2025-02-03 16:00 a minor change to the RFC
-text is made. The cooldown period is not reset, since the remaining cooldown
-period of ~12 days is longer than 1 week. On 2025-02-05 17:00 a major change to
-the RFC text is made. The cooldown period is reset to 2025-02-19 17:00. On
-2025-02-15 16:00 another minor change is made. The cooldown period is reset to
-2025-02-22 16:00. On 2025-02-21 13:00 an obvious typo is fixed. The cooldown
-period is not reset.
+Cooldowns overlap, so if a Major change is announced, and 3 days later a Minor
+change is announced, the vote may be called 11 days (14 - 3) later.
 
-
-
-
-The discussion phase MAY be extended beyond the required cooldown period. It
-SHOULD appropriately be extended in holiday periods or in cases of significant
+The discussion is not required to go to a vote at any particular point.  The author(s)
+MAY continue the discussion as long as they wish.  The author(s) SHOULD
+be mindful of extended in holiday periods or in cases of significant
 activity on the mailing list to allow everyone to catch up with the discussion.
 
 After a period of 6 weeks without any email in the official discussion thread,

--- a/feature-proposals.rst
+++ b/feature-proposals.rst
@@ -133,6 +133,11 @@ An RFC author MAY start a vote at any time, provided that:
   The author(s) may determine what qualifies as relevant and substantive, but SHOULD be
   liberal in interpreting that.
 
+If there are any secondary votes included, the RFC text describing the vote MUST include
+whether the secondary vote is plurality or Single-Transferrable Vote, how ties will be handled,
+whether it is a 2/3 majority Yes/No or a 50% threshold, and any other pertinent information
+to ensure the implications of the secondary vote are clearly understood.
+
 =================
 Voting procedure
 =================
@@ -144,7 +149,7 @@ The voting announcement email MUST include:
 
 - A link to the Wiki page of the RFC.
 - A link to the discussion thread.
-- The number of votes to cast, in case of a multi-vote RFC.
+- A notice if there are multiple votes to cast, as each requires a separate form submission.
 - The exact date and time the vote will end, with minute precision and timezone.
 
 The end of the vote MUST additionally be specified in the voting widget on the
@@ -163,8 +168,8 @@ December, 17th 00:00 UTC and January, 10th 00:00 UTC.
 After the voting period has started, including after the vote closed and the RFC is
 either accepted or declined, there MUST NOT be any further major or minor
 changes to the RFC text and making editorial changes SHOULD be avoided for the
-avoidance of doubt. The voting formalities (including the voting period) MUST
-NOT be changed after the vote opened.
+avoidance of doubt. The voting details (such as the voting period or interpretation
+of secondary votes) MUST NOT be changed after the vote opened.
 
 The voting period MAY be canceled within the first 2 days (48 hours) in case
 of severe issues with the RFC. Canceling a vote is treated as a Major change thus

--- a/feature-proposals.rst
+++ b/feature-proposals.rst
@@ -85,16 +85,16 @@ change is announced, the vote may be called 11 days (14 - 3) later.
 
 The discussion is not required to go to a vote at any particular point.  The author(s)
 MAY continue the discussion as long as they wish.  The author(s) SHOULD
-be mindful of extended in holiday periods or in cases of significant
-activity on the mailing list to allow everyone to catch up with the discussion.
+be mindful of holiday periods or in cases of significant activity on the mailing list
+to allow everyone to catch up with the discussion.
 
-After a period of 6 weeks without any email in the official discussion thread,
-the discussion is considered inactive and MUST be restarted with a cooldown
-period of 1 week (168 hours) before the RFC may proceed to a vote, since it is
-likely that other RFC discussions are at the top of mind of the mailing list
-participants. After a period of 3 months without any email in the official
-discussion thread, the discussion MUST be restarted with a cooldown period of 2
-weeks (336 hours).
+In order to keep RFCs "fresh," their discussion threads must have a minimum level of
+activity.  Any message to the discussion thread from anyone other than a voting announcement
+is sufficient to keep the RFC active.  Once an RFC discussion goes inactive, any
+new post will "reactivate" the discussion and trigger a new cooldown period.
+
+- If it has been 6 weeks since the last message, the cooldown is 1 week (168 hours).
+- If it has been 3 months since the last message, the cooldown is 2 week (336 hours).
 
 **************
  Voting Phase

--- a/feature-proposals.rst
+++ b/feature-proposals.rst
@@ -137,11 +137,8 @@ An RFC author MAY start a vote at any time, provided that:
    the thread. The author(s) may determine what qualifies as relevant and
    substantive, but SHOULD be liberal in interpreting that.
 
-If there are any secondary votes included, the RFC text describing the vote MUST
-include whether the secondary vote is plurality or Single-Transferrable Vote,
-how ties will be handled, whether it is a 2/3 majority Yes/No or a 50%
-threshold, and any other pertinent information to ensure the implications of the
-secondary vote are clearly understood.
+All voting widgets on the RFC MUST include all pertinent details for that vote, as
+described in the "Required Majority" section below.
 
 Voting procedure
 ================

--- a/feature-proposals.rst
+++ b/feature-proposals.rst
@@ -89,7 +89,7 @@ vote may be called. Editorial changes do not trigger a cooldown period.
 -  The cooldown after a Major change announcement is 14 days.
 -  The cooldown after a Minor announcement is 7 days.
 
-By implication, it means the minimum discussion period for any RFC is 2 weeks,
+By implication, it means the minimum discussion period for any RFC is 14 days,
 assuming no changes are made after the initial proposal.
 
 Cooldowns overlap, so if a Major change is announced, and 3 days later a Minor
@@ -120,7 +120,7 @@ Voting prerequisites
 ====================
 
 Prior to starting a vote, RFC authors MUST post an Intent to Vote message to
-the discussion thread. The post MUST be made at least two days and no more than
+the discussion thread. The post MUST be made at least 2 days and no more than
 7 days before the vote is officially opened. Any feedback posted
 after the Intent to Vote message is sent SHOULD be treated the same as if it had
 been sent earlier, and any Major or Minor changes that result from that feedback
@@ -182,7 +182,7 @@ changes to the RFC text and making editorial changes SHOULD be avoided for the
 avoidance of doubt. The voting details (such as the voting period or
 interpretation of secondary votes) MUST NOT be changed after the vote opened.
 
-The voting period MAY be canceled within the first 2 days (48 hours) in case of
+The voting period MAY be canceled within the first 2 days in case of
 severe issues with the RFC. Canceling a vote is treated as a Major change thus
 triggers a new cooldown period. The title of all voting widgets MUST be changed
 to invalidate any votes that have been cast (e.g. by adding the suffix

--- a/feature-proposals.rst
+++ b/feature-proposals.rst
@@ -79,20 +79,20 @@ in response to that email. If a series of changes are included together, the
 whole announcement belongs to the highest level of any of the involved changes.
 The initial proposal of the RFC is considered a Major change announcement.
 
-Cooldown period
+Cooldown Period
 ===============
 
-Both Major and Minor change announcements trigger a "cooldown period" to allow
-for sufficient discussion of the related changes. During the cooldown period, no
-vote may be called. Editorial changes do not trigger a cooldown period.
+Both Major and Minor change announcements trigger a "Cooldown Period" to allow
+for sufficient discussion of the related changes. During the Cooldown Period, no
+vote may be called. Editorial changes do not trigger a Cooldown Period.
 
--  The cooldown after a Major change announcement is 14 days.
--  The cooldown after a Minor announcement is 7 days.
+-  The Cooldown Period after a Major change announcement is 14 days.
+-  The Cooldown Period after a Minor announcement is 7 days.
 
 By implication, it means the minimum discussion period for any RFC is 14 days,
 assuming no changes are made after the initial proposal.
 
-Cooldowns overlap, so if a Major change is announced, and 3 days later a Minor
+Cooldown Periods overlap, so if a Major change is announced, and 3 days later a Minor
 change is announced, the vote may be called 11 days (14 - 3) later.
 
 Discussion lifetime
@@ -107,10 +107,10 @@ In order to keep RFCs "fresh," their discussion threads must have a minimum
 level of activity. Any message to the discussion thread from any participant 
 (excluding “Intent to Vote” messages) is sufficient to keep the RFC active. Once an RFC discussion
 goes inactive, any new post will "reactivate" the discussion and trigger a new
-cooldown period.
+Cooldown Period.
 
--  If it has been 42 days (~6 weeks) since the last message, the cooldown is 7 days.
--  If it has been 90 days (~3 months) since the last message, the cooldown is 14 days.
+-  If it has been 42 days (~6 weeks) since the last message, the Cooldown Period is 7 days.
+-  If it has been 90 days (~3 months) since the last message, the Cooldown Period is 14 days.
 
 **************
  Voting Phase
@@ -124,11 +124,11 @@ the discussion thread. The post MUST be made at least 2 days and no more than
 7 days before the vote is officially opened (“Intent to Vote lifetime”). Any feedback posted
 after the Intent to Vote message is sent SHOULD be treated the same as if it had
 been sent earlier, and any Major or Minor changes that result from that feedback
-MUST trigger a new cooldown period, canceling the Intent to Vote.
+MUST trigger a new Cooldown Period, canceling the Intent to Vote.
 
 RFC authors MAY start a vote at any time, provided that all the following conditions hold:
 
--  There is no cooldown period still active.
+-  There is no Cooldown Period still active.
 
 -  The discussion thread is not inactive.
 
@@ -145,7 +145,7 @@ described in the "Required Majority" section below.
 To account for minor calculation errors due to timezone changes,
 outside commitments by RFC authors, and others deadlines, RFC
 authors MAY use a grace period of up to 8 hours in either direction
-without being in violation of the cooldown period and the Intent
+without being in violation of the Cooldown Period and the Intent
 to Vote lifetime. RFC authors SHOULD nevertheless strive to
 observe the cut-off timestamps as closely as possible.
 
@@ -154,7 +154,7 @@ but discouraged:
 
 - Starting a vote 45 hours after the Intent to Vote has been posted.
 - Starting the vote 7 days and 3 hours after the Intent to Vote was posted.
-- Starting the vote 6 days and 20 hours after a Minor change cooldown period started.
+- Starting the vote 6 days and 20 hours after a Minor change Cooldown Period started.
 
 Voting procedure
 ================
@@ -192,7 +192,7 @@ interpretation of secondary votes) MUST NOT be changed after the vote opened.
 
 The voting period MAY be canceled within the first 2 days in case of
 severe issues with the RFC. Canceling a vote is treated as a Major change thus
-triggers a new cooldown period. The title of all voting widgets MUST be changed
+triggers a new Cooldown Period. The title of all voting widgets MUST be changed
 to invalidate any votes that have been cast (e.g. by adding the suffix
 “(Restart)”).
 

--- a/feature-proposals.rst
+++ b/feature-proposals.rst
@@ -41,6 +41,30 @@ for improving the RFC, as extensive or minimalist as they see fit.  However,
 unrelated discussions that spin off to discuss other, related topics SHOULD
 be moved to their own email threads to minimize noise.
 
+The author(s) of the RFC MAY make changes to the proposal at any time during the
+discussion.  Changes broadly fall into one of three categories:
+
+- **Major changes** to the RFC text include any changes that would lead to a change in
+  the implementation, particularly any changes to the proposed semantics or
+  syntax, updating the API stub. It also includes adding, changing or removing
+  any voting widget.
+- **Minor** changes to the RFC text include adding new examples, updating existing
+  examples, adding additional explanation or clarification, or any other changes
+  that are not purely editorial.
+- **Editorial changes** to the RFC text include non-substantive changes, such as
+  spelling, typos, changing section labels, bug fixes to existing code examples,
+  small rewordings of descriptions, and so forth.
+
+If it is unclear what level a change belongs in, the author(s) SHOULD assume the
+higher one.
+
+Major and minor changes MUST be announced in the official discussion thread,
+either in a dedicated email summarizing a list of changes or in a reply to
+another email that clearly indicates that changes to the RFC text have been made
+in response to that email.  If a series of changes are included together, the whole
+announcement belongs to the highest level of any of the involved changes.  The
+initial proposal of the RFC is considered a Major change announcement.
+
 Before an RFC may move to the voting phase a cooldown period of 2 weeks (336
 hours) MUST have elapsed. The cooldown period starts at the time of the initial
 email of the official RFC discussion thread.
@@ -51,10 +75,7 @@ features and references) the cooldown period MUST be reset. The cooldown period
 MUST be reset to 2 weeks (336 hours) in case of major changes. It MUST be reset
 to 1 week (168 hours) in case of minor changes if the current remaining cooldown
 period is shorter. When in doubt, the change MUST be treated as a major change.
-Major and minor changes MUST be announced in the official discussion thread,
-either in a dedicated email summarizing a list of changes or in a reply to
-another email that clearly indicates that changes to the RFC text have been made
-in response to that email.
+
 
 As an example: An RFC is announced at 2025-02-01 15:00. The initial cooldown
 period ends at 2025-02-15 15:00. On 2025-02-03 16:00 a minor change to the RFC
@@ -65,12 +86,8 @@ the RFC text is made. The cooldown period is reset to 2025-02-19 17:00. On
 2025-02-22 16:00. On 2025-02-21 13:00 an obvious typo is fixed. The cooldown
 period is not reset.
 
-Major changes to the RFC text include any changes that would lead to a change in
-the implementation, particularly any changes to the proposed semantics or
-syntax, updating the API stub, adding, changing or removing any voting widget.
-Minor changes to the RFC text include adding new examples, updating existing
-examples, adding additional explanation or clarification, or any other changes
-that are not purely editorial.
+
+
 
 The discussion phase MAY be extended beyond the required cooldown period. It
 SHOULD appropriately be extended in holiday periods or in cases of significant

--- a/feature-proposals.rst
+++ b/feature-proposals.rst
@@ -32,6 +32,11 @@ a new Wiki page containing an RFC with a unique title MUST be created. In this
 case the original RFC's title is commonly suffixed with ``v2`` to indicate the
 relationship with the original RFC.
 
+A proposal or proposal concept MAY be discussed informally on the list prior
+to an official initiation post.  In many cases that is encouraged to get a
+sense of how well received a proposal would be.  However, that does not count
+toward the Discussion Phase.
+
 ******************
  Discussion Phase
 ******************
@@ -90,10 +95,6 @@ likely that other RFC discussions are at the top of mind of the mailing list
 participants. After a period of 3 months without any email in the official
 discussion thread, the discussion MUST be restarted with a cooldown period of 2
 weeks (336 hours).
-
-This does not preclude discussion on the merits on any idea or proposal on the
-list without formally submitting it as a proposal, but the cooldown period is
-measured only since the formal discussion announcement as described above.
 
 **************
  Voting Phase

--- a/feature-proposals.rst
+++ b/feature-proposals.rst
@@ -49,7 +49,7 @@ SHOULD be moved to their own email threads to minimize noise.
 Types of changes
 ================
 
-The author(s) of the RFC MAY make changes to the proposal at any time during the
+The authors of the RFC MAY make changes to the proposal at any time during the
 discussion. Changes broadly fall into one of three categories:
 
 -  **Major changes** to the RFC text include any changes that would lead to a
@@ -65,7 +65,7 @@ discussion. Changes broadly fall into one of three categories:
    as spelling, typos, changing section labels, bug fixes to existing code
    examples, small rewordings of descriptions, and so forth.
 
-If it is unclear what level a change belongs in, the author(s) SHOULD assume the
+If it is unclear what level a change belongs in, the authors SHOULD assume the
 higher one.
 
 Major and minor changes MUST be announced in the official discussion thread,
@@ -95,7 +95,7 @@ Discussion lifetime
 ===================
 
 The discussion is not required to go to a vote at any particular point. The
-author(s) MAY continue the discussion as long as they wish. The author(s) SHOULD
+authors MAY continue the discussion as long as they wish. The authors SHOULD
 be mindful of holiday periods or periods of significant activity on the mailing
 list to allow everyone to catch up with the discussion.
 
@@ -117,24 +117,24 @@ cooldown period.
 Voting prerequisites
 ====================
 
-Prior to starting a vote, an RFC author MUST post an Intent to Vote message to
+Prior to starting a vote, RFC authors MUST post an Intent to Vote message to
 the discussion thread. The post MUST be made at least two days (48 hours) and no more than
 1 week (168 hours) before the vote is officially opened. Any feedback posted
 after the Intent to Vote message is sent SHOULD be treated the same as if it had
 been sent earlier, and any Major or Minor changes that result MUST trigger a new
 cooldown period, canceling the Intent to Vote.
 
-An RFC author MAY start a vote at any time, provided that all the following conditions hold:
+RFC authors MAY start a vote at any time, provided that all the following conditions hold:
 
 -  There is no cooldown period still active.
 
 -  The discussion thread is not inactive.
 
--  The author has posted an intent to open the vote at least 2 days prior, and
+-  The authors has posted an intent to open the vote at least 2 days prior, and
    no more than one week prior.
 
 -  There is no ongoing relevant and substantive discussion still happening in
-   the thread. The author(s) may determine what qualifies as relevant and
+   the thread. The authors may determine what qualifies as relevant and
    substantive, but SHOULD be liberal in interpreting that.
 
 All voting widgets on the RFC MUST include all pertinent details for that vote, as
@@ -189,7 +189,7 @@ section explaining the necessary changes SHOULD be added.
 
 Should the necessary changes significantly impact the design, it MAY be
 appropriate to start a follow-up discussion thread, or possibly a follow-up RFC.
-At minimum, author(s) SHOULD send a notification message to the original
+At minimum, authors SHOULD send a notification message to the original
 discussion thread describing the change.
 
 If there is dispute as to whether a post-vote change requires a follow-up
@@ -255,7 +255,7 @@ proposal up for another vote, unless one of the following happens:
 
 -  6 months pass from the time of the previous vote, **OR**
 
--  The author(s) make substantial changes to the proposal. While it's impossible
+-  The authors make substantial changes to the proposal. While it's impossible
    to put clear definitions on what constitutes 'substantial' changes, they
    should be material enough so that they'll significantly affect the outcome of
    another vote.

--- a/feature-proposals.rst
+++ b/feature-proposals.rst
@@ -9,6 +9,8 @@
 This document describes the procedure to propose an idea for adoption by the PHP
 community and decide if the community accepts or rejects the idea.
 
+The change process involves three phases: Initiation, Discussion, and Voting.
+
 *********************
  Proposal Initiation
 *********************

--- a/feature-proposals.rst
+++ b/feature-proposals.rst
@@ -11,6 +11,10 @@ community and decide if the community accepts or rejects the idea.
 
 The change process involves three phases: Initiation, Discussion, and Voting.
 
+For the purposes of this document 1 day is equal to 24 contiguous hours.  Should
+Daylight Saving Time, Leap Days, or other oddities of time handling occur,
+they will not affect the definition of a day as 24 hours of "stopwatch time."
+
 *********************
  Proposal Initiation
 *********************
@@ -82,8 +86,8 @@ Both Major and Minor change announcements trigger a "cooldown period" to allow
 for sufficient discussion of the related changes. During the cooldown period, no
 vote may be called. Editorial changes do not trigger a cooldown period.
 
--  The cooldown after a Major change announcement is 2 weeks (336 hours).
--  The cooldown after a Minor announcement is 1 week (168 hours).
+-  The cooldown after a Major change announcement is 14 days.
+-  The cooldown after a Minor announcement is 7 days.
 
 By implication, it means the minimum discussion period for any RFC is 2 weeks,
 assuming no changes are made after the initial proposal.
@@ -105,10 +109,8 @@ level of activity. Any message to the discussion thread from any participant
 goes inactive, any new post will "reactivate" the discussion and trigger a new
 cooldown period.
 
--  If it has been 6 weeks since the last message, the cooldown is 1 week (168
-   hours).
--  If it has been 3 months since the last message, the cooldown is 2 week (336
-   hours).
+-  If it has been 42 days (~6 weeks) since the last message, the cooldown is 7 days.
+-  If it has been 90 days (~3 months) since the last message, the cooldown is 14 days.
 
 **************
  Voting Phase
@@ -118,8 +120,8 @@ Voting prerequisites
 ====================
 
 Prior to starting a vote, RFC authors MUST post an Intent to Vote message to
-the discussion thread. The post MUST be made at least two days (48 hours) and no more than
-1 week (168 hours) before the vote is officially opened. Any feedback posted
+the discussion thread. The post MUST be made at least two days and no more than
+7 days before the vote is officially opened. Any feedback posted
 after the Intent to Vote message is sent SHOULD be treated the same as if it had
 been sent earlier, and any Major or Minor changes that result from that feedback
 MUST trigger a new cooldown period, canceling the Intent to Vote.
@@ -131,7 +133,7 @@ RFC authors MAY start a vote at any time, provided that all the following condit
 -  The discussion thread is not inactive.
 
 -  The authors has posted an intent to open the vote at least 2 days prior, and
-   no more than one week prior.
+   no more than 7 days prior.
 
 -  There is no ongoing relevant and substantive discussion still happening in
    the thread. The authors may determine what qualifies as relevant and
@@ -139,6 +141,12 @@ RFC authors MAY start a vote at any time, provided that all the following condit
 
 All voting widgets on the RFC MUST include all relevant details for that vote, as
 described in the "Required Majority" section below.
+
+To allow for timezone differences, outside commitments by RFC authors, and other deadlines,
+the cutoff timestamp to start a vote has a grace period of 8 hours in either direction.
+That is, starting a vote 45 hours after the Intent to Vote has been posted is discouraged, but
+allowed.  Similarly, starting the vote 7 days and 3 hours after the Intent to Vote was posted
+is discouraged, but allowed.
 
 Voting procedure
 ================
@@ -152,8 +160,7 @@ The voting announcement email MUST include:
 -  A link to the discussion thread.
 -  A notice if there are multiple votes to cast, as each requires a separate
    form submission.
--  The exact date and time the vote will end, with minute precision and
-   timezone.
+-  The date and time the vote will end.
 
 The end of the vote MUST additionally be specified in the voting widget on the
 RFC so that it will auto-close at the specified timestamp.
@@ -162,8 +169,8 @@ The link to the mailing list archives of the voting thread MUST be added to the
 RFC as soon as possible and no later than the announcement of the results of the
 vote.
 
-The voting period MUST be at least two weeks (336 hours), but MAY be up to four
-weeks (e.g. to avoid conflicts with well-known holiday periods).
+The voting period MUST be at least 14 days, but MAY be up to 28 days (e.g.
+to avoid conflicts with well-known holiday periods).
 
 Due to the significance of the end-of-year holidays for a majority of the world,
 the voting period MUST NOT start and MUST NOT end in the period between

--- a/feature-proposals.rst
+++ b/feature-proposals.rst
@@ -121,7 +121,7 @@ Voting prerequisites
 
 Prior to starting a vote, RFC authors MUST post an Intent to Vote message to
 the discussion thread. The post MUST be made at least 2 days and no more than
-7 days before the vote is officially opened. Any feedback posted
+7 days before the vote is officially opened (“Intent to Vote lifetime”). Any feedback posted
 after the Intent to Vote message is sent SHOULD be treated the same as if it had
 been sent earlier, and any Major or Minor changes that result from that feedback
 MUST trigger a new cooldown period, canceling the Intent to Vote.
@@ -142,9 +142,15 @@ RFC authors MAY start a vote at any time, provided that all the following condit
 All voting widgets on the RFC MUST include all relevant details for that vote, as
 described in the "Required Majority" section below.
 
-To allow for timezone differences, outside commitments by RFC authors, and other deadlines,
-the cutoff timestamp for the cooldown period or to start a vote has a grace period of
-8 hours in either direction. For example, the following scenarios are allowed, but discouraged.
+To account for minor calculation errors due to timezone changes,
+outside commitments by RFC authors, and others deadlines, RFC
+authors MAY use a grace period of up to 8 hours in either direction
+without being in violation of the cooldown period and the Intent
+to Vote lifetime. RFC authors SHOULD nevertheless strive to
+observe the cut-off timestamps as closely as possible.
+
+As an example, all of the following scenarios would be allowed,
+but discouraged:
 
 - Starting a vote 45 hours after the Intent to Vote has been posted.
 - Starting the vote 7 days and 3 hours after the Intent to Vote was posted.

--- a/feature-proposals.rst
+++ b/feature-proposals.rst
@@ -133,20 +133,28 @@ An RFC author MAY start a vote at any time, provided that:
   The author(s) may determine what qualifies as relevant and substantive, but SHOULD be
   liberal in interpreting that.
 
-The actual start of the vote MUST be announced on the mailing list in a separate
-thread with a ``[VOTE]`` prefix followed by the RFC title as the Subject. The
-email MUST include a link to the Wiki page of the RFC and to the mailing list
-archives of the discussion thread. The link to the mailing list archives of the
-voting thread MUST be added to the RFC as soon as possible and no later than the
-announcement of the results of the vote.
+=================
+Voting procedure
+=================
 
-The email MUST furthermore clearly specify the voting formalities, such as the
-number of votes that can be cast, the interpretation of the voting results and
-the end date of the voting. The end date MUST be specified with minute-precision
-and is not part of the voting period, all votes must be cast before the
-specified end date. The voting period MUST be open for at least two weeks (336
-hours). The voting period MAY be extended as necessary (e.g. to accommodate
-holiday periods).
+The actual start of the vote MUST be announced on the mailing list in a separate
+thread with a ``[VOTE]`` prefix followed by the RFC title as the Subject.
+
+The voting announcement email MUST include:
+
+- A link to the Wiki page of the RFC.
+- A link to the discussion thread.
+- The number of votes to cast, in case of a multi-vote RFC.
+- The exact date and time the vote will end, with minute precision and timezone.
+
+The end of the vote MUST additionally be specified in the voting widget on the
+RFC so that it will auto-close at the specified timestamp.
+
+The link to the mailing list archives of the voting thread MUST be added to
+the RFC as soon as possible and no later than the announcement of the results of the vote.
+
+The voting period MUST be at least two weeks (336 hours), but MAY be up to
+four weeks if necessary to avoid conflict with well-known holiday periods.
 
 Due to the significance of the end-of-year holidays for a majority of the world,
 the voting period MUST NOT start and MUST NOT end in the period between

--- a/feature-proposals.rst
+++ b/feature-proposals.rst
@@ -32,37 +32,38 @@ a new Wiki page containing an RFC with a unique title MUST be created. In this
 case the original RFC's title is commonly suffixed with ``v2`` to indicate the
 relationship with the original RFC.
 
-A proposal or proposal concept MAY be discussed informally on the list prior
-to an official initiation post.  In many cases that is encouraged to get a
-sense of how well received a proposal would be.  However, that does not count
-toward the Discussion Phase.
+A proposal or proposal concept MAY be discussed informally on the list prior to
+an official initiation post. In many cases that is encouraged to get a sense of
+how well received a proposal would be. However, that does not count toward the
+Discussion Phase.
 
 ******************
  Discussion Phase
 ******************
 
-In the Discussion Phase, the community may review, discuss, and offer suggestions
-for improving the RFC, as extensive or minimalist as they see fit.  However,
-unrelated discussions that spin off to discuss other, related topics SHOULD
-be moved to their own email threads to minimize noise.
+In the Discussion Phase, the community may review, discuss, and offer
+suggestions for improving the RFC, as extensive or minimalist as they see fit.
+However, unrelated discussions that spin off to discuss other, related topics
+SHOULD be moved to their own email threads to minimize noise.
 
-=================
 Types of changes
-=================
+================
 
 The author(s) of the RFC MAY make changes to the proposal at any time during the
-discussion.  Changes broadly fall into one of three categories:
+discussion. Changes broadly fall into one of three categories:
 
-- **Major changes** to the RFC text include any changes that would lead to a change in
-  the implementation, particularly any changes to the proposed semantics or
-  syntax, updating the API stub. It also includes adding, changing or removing
-  any voting widget.
-- **Minor** changes to the RFC text include adding new examples, updating existing
-  examples, adding additional explanation or clarification, or any other changes
-  that are not purely editorial.
-- **Editorial changes** to the RFC text include non-substantive changes, such as
-  spelling, typos, changing section labels, bug fixes to existing code examples,
-  small rewordings of descriptions, and so forth.
+-  **Major changes** to the RFC text include any changes that would lead to a
+   change in the implementation, particularly any changes to the proposed
+   semantics or syntax, updating the API stub. It also includes adding, changing
+   or removing any voting widget.
+
+-  **Minor** changes to the RFC text include adding new examples, updating
+   existing examples, adding additional explanation or clarification, or any
+   other changes that are not purely editorial.
+
+-  **Editorial changes** to the RFC text include non-substantive changes, such
+   as spelling, typos, changing section labels, bug fixes to existing code
+   examples, small rewordings of descriptions, and so forth.
 
 If it is unclear what level a change belongs in, the author(s) SHOULD assume the
 higher one.
@@ -70,20 +71,19 @@ higher one.
 Major and minor changes MUST be announced in the official discussion thread,
 either in a dedicated email summarizing a list of changes or in a reply to
 another email that clearly indicates that changes to the RFC text have been made
-in response to that email.  If a series of changes are included together, the whole
-announcement belongs to the highest level of any of the involved changes.  The
-initial proposal of the RFC is considered a Major change announcement.
+in response to that email. If a series of changes are included together, the
+whole announcement belongs to the highest level of any of the involved changes.
+The initial proposal of the RFC is considered a Major change announcement.
 
-================
 Cooldown period
-================
+===============
 
-Both Major and Minor change announcements trigger a "cooldown period" to allow for
-sufficient discussion of the related changes.  During the cooldown period, no vote
-may be called.  Editorial changes do not trigger a cooldown period.
+Both Major and Minor change announcements trigger a "cooldown period" to allow
+for sufficient discussion of the related changes. During the cooldown period, no
+vote may be called. Editorial changes do not trigger a cooldown period.
 
-- The cooldown after a Major change announcement is 2 weeks (336 hours).
-- The cooldown after a Minor announcement is 1 week (168 hours).
+-  The cooldown after a Major change announcement is 2 weeks (336 hours).
+-  The cooldown after a Minor announcement is 1 week (168 hours).
 
 By implication, it means the minimum discussion period for any RFC is 2 weeks,
 assuming no changes are made after the initial proposal.
@@ -91,94 +91,101 @@ assuming no changes are made after the initial proposal.
 Cooldowns overlap, so if a Major change is announced, and 3 days later a Minor
 change is announced, the vote may be called 11 days (14 - 3) later.
 
-====================
 Discussion lifetime
-====================
+===================
 
-The discussion is not required to go to a vote at any particular point.  The author(s)
-MAY continue the discussion as long as they wish.  The author(s) SHOULD
-be mindful of holiday periods or in cases of significant activity on the mailing list
-to allow everyone to catch up with the discussion.
+The discussion is not required to go to a vote at any particular point. The
+author(s) MAY continue the discussion as long as they wish. The author(s) SHOULD
+be mindful of holiday periods or in cases of significant activity on the mailing
+list to allow everyone to catch up with the discussion.
 
-In order to keep RFCs "fresh," their discussion threads must have a minimum level of
-activity.  Any message to the discussion thread from anyone other than an Intent to Vote
-is sufficient to keep the RFC active.  Once an RFC discussion goes inactive, any
-new post will "reactivate" the discussion and trigger a new cooldown period.
+In order to keep RFCs "fresh," their discussion threads must have a minimum
+level of activity. Any message to the discussion thread from anyone other than
+an Intent to Vote is sufficient to keep the RFC active. Once an RFC discussion
+goes inactive, any new post will "reactivate" the discussion and trigger a new
+cooldown period.
 
-- If it has been 6 weeks since the last message, the cooldown is 1 week (168 hours).
-- If it has been 3 months since the last message, the cooldown is 2 week (336 hours).
+-  If it has been 6 weeks since the last message, the cooldown is 1 week (168
+   hours).
+-  If it has been 3 months since the last message, the cooldown is 2 week (336
+   hours).
 
 **************
  Voting Phase
 **************
 
-=====================
 Voting prerequisites
-=====================
+====================
 
 Prior to starting a vote, an RFC author MUST post an Intent to Vote message to
-the discussion thread.  The post MUST be made at least two days and no more than 1 week
-(168 hours) before the vote is officially opened.  Any feedback posted after the Intent
-to Vote message is sent SHOULD be treated the same as if it had been sent earlier,
-and any Major or Minor changes that result MUST trigger a new cooldown period,
-canceling the Intent to Vote.
+the discussion thread. The post MUST be made at least two days and no more than
+1 week (168 hours) before the vote is officially opened. Any feedback posted
+after the Intent to Vote message is sent SHOULD be treated the same as if it had
+been sent earlier, and any Major or Minor changes that result MUST trigger a new
+cooldown period, canceling the Intent to Vote.
 
 An RFC author MAY start a vote at any time, provided that:
 
-- There is no cooldown period still active.
-- The discussion thread is not inactive.
-- The author has posted an intent to open the vote at least 48 hours prior, and no more
-  than one week prior.
-- There is no ongoing relevant and substantive discussion still happening in the thread.
-  The author(s) may determine what qualifies as relevant and substantive, but SHOULD be
-  liberal in interpreting that.
+-  There is no cooldown period still active.
 
-If there are any secondary votes included, the RFC text describing the vote MUST include
-whether the secondary vote is plurality or Single-Transferrable Vote, how ties will be handled,
-whether it is a 2/3 majority Yes/No or a 50% threshold, and any other pertinent information
-to ensure the implications of the secondary vote are clearly understood.
+-  The discussion thread is not inactive.
 
-=================
+-  The author has posted an intent to open the vote at least 48 hours prior, and
+   no more than one week prior.
+
+-  There is no ongoing relevant and substantive discussion still happening in
+   the thread. The author(s) may determine what qualifies as relevant and
+   substantive, but SHOULD be liberal in interpreting that.
+
+If there are any secondary votes included, the RFC text describing the vote MUST
+include whether the secondary vote is plurality or Single-Transferrable Vote,
+how ties will be handled, whether it is a 2/3 majority Yes/No or a 50%
+threshold, and any other pertinent information to ensure the implications of the
+secondary vote are clearly understood.
+
 Voting procedure
-=================
+================
 
 The actual start of the vote MUST be announced on the mailing list in a separate
 thread with a ``[VOTE]`` prefix followed by the RFC title as the Subject.
 
 The voting announcement email MUST include:
 
-- A link to the Wiki page of the RFC.
-- A link to the discussion thread.
-- A notice if there are multiple votes to cast, as each requires a separate form submission.
-- The exact date and time the vote will end, with minute precision and timezone.
+-  A link to the Wiki page of the RFC.
+-  A link to the discussion thread.
+-  A notice if there are multiple votes to cast, as each requires a separate
+   form submission.
+-  The exact date and time the vote will end, with minute precision and
+   timezone.
 
 The end of the vote MUST additionally be specified in the voting widget on the
 RFC so that it will auto-close at the specified timestamp.
 
-The link to the mailing list archives of the voting thread MUST be added to
-the RFC as soon as possible and no later than the announcement of the results of the vote.
+The link to the mailing list archives of the voting thread MUST be added to the
+RFC as soon as possible and no later than the announcement of the results of the
+vote.
 
-The voting period MUST be at least two weeks (336 hours), but MAY be up to
-four weeks if necessary to avoid conflict with well-known holiday periods.
+The voting period MUST be at least two weeks (336 hours), but MAY be up to four
+weeks if necessary to avoid conflict with well-known holiday periods.
 
 Due to the significance of the end-of-year holidays for a majority of the world,
 the voting period MUST NOT start and MUST NOT end in the period between
 December, 17th 00:00 UTC and January, 10th 00:00 UTC.
 
-After the voting period has started, including after the vote closed and the RFC is
-either accepted or declined, there MUST NOT be any further major or minor
+After the voting period has started, including after the vote closed and the RFC
+is either accepted or declined, there MUST NOT be any further major or minor
 changes to the RFC text and making editorial changes SHOULD be avoided for the
-avoidance of doubt. The voting details (such as the voting period or interpretation
-of secondary votes) MUST NOT be changed after the vote opened.
+avoidance of doubt. The voting details (such as the voting period or
+interpretation of secondary votes) MUST NOT be changed after the vote opened.
 
-The voting period MAY be canceled within the first 2 days (48 hours) in case
-of severe issues with the RFC. Canceling a vote is treated as a Major change thus
-triggers a new cooldown period. The title of all voting widgets MUST be
-changed to invalidate any votes that have been cast (e.g. by adding the suffix “(Restart)”).
+The voting period MAY be canceled within the first 2 days (48 hours) in case of
+severe issues with the RFC. Canceling a vote is treated as a Major change thus
+triggers a new cooldown period. The title of all voting widgets MUST be changed
+to invalidate any votes that have been cast (e.g. by adding the suffix
+“(Restart)”).
 
-=======
 Errata
-=======
+======
 
 If issues with an accepted RFC are noticed during implementation, an errata
 section explaining the necessary changes SHOULD be added.

--- a/feature-proposals.rst
+++ b/feature-proposals.rst
@@ -171,8 +171,21 @@ of severe issues with the RFC. Canceling a vote is treated as a Major change thu
 triggers a new cooldown period. The title of all voting widgets MUST be
 changed to invalidate any votes that have been cast (e.g. by adding the suffix “(Restart)”).
 
+=======
+Errata
+=======
+
 If issues with an accepted RFC are noticed during implementation, an errata
 section explaining the necessary changes SHOULD be added.
+
+Should the necessary changes significantly impact the design, it MAY be
+appropriate to start a follow-up discussion thread, or possibly a follow-up RFC.
+At minimum, author(s) SHOULD send a notification message to the original
+discussion thread describing the change.
+
+If there is dispute as to whether a post-vote change requires a follow-up
+discussion of its own, an RFC and vote of its own, or neither, the final
+decision rests with the Release Managers.
 
 This section has been amended by:
 


### PR DESCRIPTION
My proposed language cleanup for this RFC.

This is about 95% just moving words around, adding bullet points, section headers, etc.  I tried to keep it to a bunch of small commits for easier reviewing and cherry-picking if necessary.  There are a few minor additions or changes.  In most cases I tried to keep those to their own commits, though there's a few small changes that may not have been.

I believe on the whole this describes essentially the same process, but is worded in a much clearer, more compact way.  Especially breaking up the text with lists and headers can help with readability and keep a reader from "checking out" at a wall of text.